### PR TITLE
chore: Update release workflow to handle absence of previous tags

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -164,13 +164,19 @@ jobs:
 
       - name: Determine last release tag
         run: |
-          PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          PREV_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
           echo "PREV_TAG=$PREV_TAG" >> $GITHUB_ENV
 
       - name: Create new release branch from last tag
         run: |
           git fetch --tags origin
-          git checkout -b ${{ env.RELEASE_BRANCH_NAME }} "$PREV_TAG"
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous releases found. Creating release branch from main branch."
+            git checkout -b ${{ env.RELEASE_BRANCH_NAME }} main
+          else
+            echo "Creating release branch from previous tag: $PREV_TAG"
+            git checkout -b ${{ env.RELEASE_BRANCH_NAME }} "$PREV_TAG"
+          fi
 
       - name: Merge in the just-closed PR
         run: |


### PR DESCRIPTION
Modified the release workflow to check for the existence of a previous release tag before creating a new release branch. If no previous tag is found, the workflow now creates the release branch from the main branch instead. This change improves the robustness of the release process by ensuring that a valid branch is always created.