### PR TITLE
chore: Remove key features section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,6 @@
 
 DocSearch is an advanced document search and retrieval system that leverages Retrieval-Augmented Generation (RAG) to provide intelligent natural language search capabilities across PDF document collections. This system combines sophisticated PDF processing, vector embeddings, and large language models to enable semantic understanding of document content and context-aware responses to complex queries.
 
-
-## Key Features
-
-- Intelligent PDF Processing: Automatically extracts text from PDFs using both direct text extraction and AI-powered image-to-text conversion for documents with complex layouts, images, and tables.
-- Semantic Search: Goes beyond keyword matching to understand the meaning and context of queries, retrieving relevant information even when exact terms aren't used.
-- Evidence-Based Responses: Generates comprehensive answers with citations to source documents, enabling users to verify information and explore related content.
-- Multi-Document Context: Synthesizes information across multiple documents, identifying connections and providing holistic answers to complex questions.
-- Customizable Query Engines: Offers multiple retrieval approaches depending on user needs, from direct document retrieval to fully synthesized responses with citations.
-
 ## Installation
 
 ```bash


### PR DESCRIPTION
Deleted the Key Features section from the README.md file to streamline the documentation. This change aims to simplify the content and focus on the core description of the DocSearch system without overwhelming users with extensive feature details.